### PR TITLE
Pythonのページを追加

### DIFF
--- a/pages/Python.md
+++ b/pages/Python.md
@@ -1,0 +1,8 @@
+---
+sort: 3
+---
+# Python
+
+- [Python 3.7 ドキュメント](https://docs.python.org/ja/3.7/){:target="_blank"}
+- Python インストール（[Windows](https://drive.google.com/open?id=1wIMzs6Hqnpa8_S1rq6gRjYW2lNuNaEQRynt5BJFkFVI){:target="_blank"},[Mac](https://drive.google.com/open?id=1euMcX2DQIUjZRkNUN5-Msd5vOPhMdiWZG8w9jMl2I1Q){:target="_blank"}）
+- [Python 実行方法](https://drive.google.com/open?id=1vbJDavKES6KsAZce6jhPE8Kv4WpgqhrmXKe8VkP44p8){:target="_blank"}


### PR DESCRIPTION
Pythonのページを作成しました。
VSCodeのプレビュー欄では、{:target="_blank"}が埋め込まれず通常テキストとして見えてしまっていたのですが、正しく反映されるでしょうか…
ご確認よろしくお願いします！